### PR TITLE
Add tracking support to monitor timings and blocks/allows

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 887b848eb3cfb4243d0d61634c8ede5c829ad60e7acdefbc1576fcedb20bfc42
-updated: 2016-04-19T23:30:11.811140038Z
+updated: 2016-04-20T17:46:27.92647028Z
 imports:
 - name: github.com/inconshreveable/go-vhost
   version: 8cbc5089df5ba3e44644d39e8d1ec375d6d842f9
@@ -8,5 +8,5 @@ imports:
   subpackages:
   - event
 - name: github.com/zpencerq/goproxy
-  version: dfd9ea04faf410cfac1437e58fe1e1a27300e56f
+  version: 8ea60905b10d2dad6b76e64f3b360937977c96a9
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -8,5 +8,5 @@ imports:
   subpackages:
   - event
 - name: github.com/zpencerq/goproxy
-  version: 8ea60905b10d2dad6b76e64f3b360937977c96a9
+  version: 4ccd60b5119b4472b818e6d74d965e799ca5f312
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,18 @@
-hash: 887b848eb3cfb4243d0d61634c8ede5c829ad60e7acdefbc1576fcedb20bfc42
-updated: 2016-04-20T17:46:27.92647028Z
+hash: e90b53e7bf283815e8ae78fd99868e7324382a4d41e4c6dbd85f47d9535ca823
+updated: 2016-04-25T18:23:05.538137597Z
 imports:
+- name: github.com/alexcesaro/statsd
+  version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
 - name: github.com/inconshreveable/go-vhost
   version: 8cbc5089df5ba3e44644d39e8d1ec375d6d842f9
+- name: github.com/influxdata/influxdb
+  version: f608e4cdb0482102471004b44fd7b7f18509d14b
+  subpackages:
+  - client/v2
+  - models
+  - pkg/escape
 - name: github.com/quipo/statsd
   version: 494c2067718d0c58116be15337f466e393273617
-  subpackages:
-  - event
 - name: github.com/zpencerq/goproxy
   version: 4ccd60b5119b4472b818e6d74d965e799ca5f312
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,12 @@
-hash: 40de77b3df8d22dfd373c5a38af9af507baa2dd21d45ca275116e6d846f1d54d
-updated: 2016-02-21T20:40:12.501004688Z
+hash: 887b848eb3cfb4243d0d61634c8ede5c829ad60e7acdefbc1576fcedb20bfc42
+updated: 2016-04-19T23:30:11.811140038Z
 imports:
 - name: github.com/inconshreveable/go-vhost
   version: 8cbc5089df5ba3e44644d39e8d1ec375d6d842f9
+- name: github.com/quipo/statsd
+  version: 494c2067718d0c58116be15337f466e393273617
+  subpackages:
+  - event
 - name: github.com/zpencerq/goproxy
-  version: 4ccd60b5119b4472b818e6d74d965e799ca5f312
+  version: dfd9ea04faf410cfac1437e58fe1e1a27300e56f
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,4 @@ package: smykowski
 import:
   - package: github.com/zpencerq/goproxy
   - package: github.com/inconshreveable/go-vhost
+  - package: github.com/quipo/statsd

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,3 +3,4 @@ import:
   - package: github.com/zpencerq/goproxy
   - package: github.com/inconshreveable/go-vhost
   - package: github.com/quipo/statsd
+  - package: github.com/influxdata/influxdb/client/v2

--- a/influxdb.go
+++ b/influxdb.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	influx "github.com/influxdata/influxdb/client/v2"
+)
+
+type InfluxConfig struct {
+	// influx.UDPConfig
+	Addr        string
+	PayloadSize int
+
+	// influx.BatchPointsConfig
+	Precision        string
+	Database         string
+	RetentionPolicy  string
+	WriteConsistency string
+}
+
+type InfluxDataClient struct {
+	influx.Client
+	conf    InfluxConfig
+	udpConf influx.UDPConfig
+	bpConf  influx.BatchPointsConfig
+	err     error
+}
+
+func (c *InfluxDataClient) Errored() bool {
+	return c.err != nil
+}
+
+func NewInfluxDataClient(conf InfluxConfig) (*InfluxDataClient, error) {
+	udpConfig := influx.UDPConfig{Addr: conf.Addr, PayloadSize: conf.PayloadSize}
+	udpClient, err := influx.NewUDPClient(udpConfig)
+
+	bpConfig := influx.BatchPointsConfig{
+		Database:         conf.Database,
+		RetentionPolicy:  conf.RetentionPolicy,
+		WriteConsistency: conf.WriteConsistency,
+	}
+
+	return &InfluxDataClient{
+		Client:  udpClient,
+		conf:    conf,
+		udpConf: udpConfig,
+		bpConf:  bpConfig,
+		err:     err,
+	}, err
+}
+
+type InfluxDataTracker struct {
+	*InfluxDataClient
+}
+
+func NewInfluxDataTracker(client *InfluxDataClient) *InfluxDataTracker {
+	return &InfluxDataTracker{client}
+}
+
+func (st *InfluxDataTracker) Track(event *Event) error {
+	if st.Errored() {
+		st.InfluxDataClient, err = NewInfluxDataClient(st.InfluxDataClient.conf)
+		if nil != err {
+			log.Println(err)
+		}
+	}
+
+	tags := make(map[string]string)
+
+	if event.Properties["Tags"] == nil {
+		event.Properties["Tags"] = make(map[string]string)
+	}
+
+	for k, v := range event.Properties["Tags"].(map[string]string) {
+		tags[k] = v
+	}
+
+	fields := make(map[string]interface{})
+	for k, v := range event.Properties {
+		if k != "Tags" {
+			switch v := v.(type) {
+			case time.Duration:
+				fields[k] = int64(v / time.Millisecond)
+			default:
+				fields[k] = v
+			}
+		}
+	}
+	for k, v := range tags {
+		if _, present := fields[k]; present {
+			fields[k] = v
+		}
+	}
+
+	point, err := influx.NewPoint(event.Event,
+		tags,
+		fields,
+		time.Now(),
+	)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	batchPoints, err := influx.NewBatchPoints(st.InfluxDataClient.bpConf)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	batchPoints.AddPoint(point)
+	err = st.Write(batchPoints)
+
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -16,13 +16,14 @@ import (
 )
 
 var (
-	verbose    *bool
-	http_addr  *string
-	https_addr *string
-	host_file  *string
-	cert_file  *string
-	key_file   *string
-	err        error
+	verbose     *bool
+	http_addr   *string
+	https_addr  *string
+	host_file   *string
+	cert_file   *string
+	key_file    *string
+	statsd_host *string
+	err         error
 
 	proxy *goproxy.ProxyHttpServer
 	cert  tls.Certificate
@@ -36,6 +37,7 @@ func init() {
 	host_file = flag.String("hostfile", "whitelist.lsv", "line separated host regex whitelist")
 	cert_file = flag.String("certfile", "ca.crt", "CA certificate")
 	key_file = flag.String("keyfile", "ca.key", "CA key")
+	statsd_host = flag.String("statsdhost", "localhost:8125", "StatsD host (e.g. localhost:8125)")
 	flag.Parse()
 
 	wm, err = NewWhitelistManager(*host_file)
@@ -64,6 +66,7 @@ func init() {
 
 	proxy = goproxy.NewProxyHttpServer()
 	proxy.Verbose = *verbose
+	proxy.Tracker = NewStatsdTracker(*statsd_host, "smykowski.")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ func init() {
 	)
 	if nil != err {
 		log.Println(err)
-		os.Exit(1)
 	}
 
 	tracker = NewStatsdTracker(statsd_client)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,10 @@ func init() {
 
 	proxy = goproxy.NewProxyHttpServer()
 	proxy.Verbose = *verbose
-	proxy.Tracker = NewStatsdTracker(*statsd_host, "smykowski.")
+	proxy.Tracker = goproxy.NewCompositeTracker(
+		NewStatsdTracker(*statsd_host, "smykowski."),
+		goproxy.NewLogTracker(nil),
+	)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -120,11 +119,13 @@ func startHttpsVhost() {
 			defer func(start time.Time) {
 				tracker.Track(
 					NewDurationEvent(
-						fmt.Sprintf("serve.https.%s", host),
+						"smykowski.serve",
 						start,
 						map[string]interface{}{
-							"Host":     host,
-							"Protocol": "https",
+							"Tags": map[string]string{
+								"Host":     host,
+								"Protocol": "https",
+							},
 						}),
 				)
 			}(time.Now())

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func init() {
 	statsd_host = flag.String("statsdhost", "localhost:8125", "StatsD host (e.g. localhost:8125)")
 	flag.Parse()
 
-	statsd_client, err := statsd.New(
+	statsd_client, err := NewStatsdClient(
 		statsd.Address(*statsd_host),
 		statsd.Prefix("smykowski."),
 		statsd.TagsFormat(statsd.InfluxDB),

--- a/main.go
+++ b/main.go
@@ -55,10 +55,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	tracker = NewCompositeTracker(
-		NewStatsdTracker(statsd_client),
-		NewLogTracker(nil),
-	)
+	tracker = NewStatsdTracker(statsd_client)
 
 	wm, err = NewWhitelistManager(*host_file)
 	wm.Verbose = *verbose

--- a/main.go
+++ b/main.go
@@ -51,8 +51,13 @@ func init() {
 
 	tracker = NewCompositeTracker(
 		NewInfluxDataTracker(influxClient),
-		NewLogTracker(nil),
 	)
+
+	if *verbose {
+		tracker.(*CompositeTracker).AddTracker(
+			NewLogTracker(nil),
+		)
+	}
 
 	wm, err = NewWhitelistManager(*host_file)
 	wm.Verbose = *verbose

--- a/proxy.go
+++ b/proxy.go
@@ -43,10 +43,7 @@ func SetupProxy(proxy *goproxy.ProxyHttpServer, cert tls.Certificate) {
 			if proxy.Verbose {
 				log.Printf("non-SNI request from ip - %s", ip)
 			}
-			return &goproxy.ConnectAction{
-				Action:    goproxy.ConnectMitm,
-				TLSConfig: goproxy.TLSConfigFromCA(&cert),
-			}, "*:443"
+			return goproxy.MitmConnect, "*:443"
 		}
 
 		hostaddr, _, err := net.SplitHostPort(host)

--- a/proxy.go
+++ b/proxy.go
@@ -24,7 +24,7 @@ func SetupProxy(proxy *goproxy.ProxyHttpServer, cert tls.Certificate) {
 		}
 		req.URL.Scheme = "http"
 		req.URL.Host = req.Host
-		proxy.ServeHTTPInternal(w, req)
+		proxy.ServeHTTP(w, req)
 	})
 
 	proxy.OnRequest().DoFunc(wm.ReqHandler())

--- a/proxy.go
+++ b/proxy.go
@@ -24,7 +24,7 @@ func SetupProxy(proxy *goproxy.ProxyHttpServer, cert tls.Certificate) {
 		}
 		req.URL.Scheme = "http"
 		req.URL.Host = req.Host
-		proxy.ServeHTTP(w, req)
+		proxy.ServeHTTPInternal(w, req)
 	})
 
 	proxy.OnRequest().DoFunc(wm.ReqHandler())

--- a/statsd.go
+++ b/statsd.go
@@ -1,44 +1,30 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"os"
 	"time"
 
-	"github.com/quipo/statsd"
-	"github.com/zpencerq/goproxy"
+	"github.com/alexcesaro/statsd"
 )
 
 type StatsdTracker struct {
-	*statsd.StatsdClient
+	*statsd.Client
 }
 
-func NewStatsdTracker(host string, prefix string) *StatsdTracker {
-	tracker := &StatsdTracker{statsd.NewStatsdClient(host, prefix)}
-	err := tracker.CreateSocket()
-	if nil != err {
-		log.Println(err)
-		os.Exit(1)
-	}
-	return tracker
+func NewStatsdTracker(client *statsd.Client) *StatsdTracker {
+	return &StatsdTracker{client}
 }
 
-func (st *StatsdTracker) Track(event *goproxy.Event) error {
-	host_string := event.Properties["Host"].(string)
-	if protocol, ok := event.Properties["Protocol"]; ok {
-		host_string = fmt.Sprintf("%s.%s", protocol, host_string)
-	}
-	stat := fmt.Sprintf("%s.%s", event.Event, host_string)
-
+func (st *StatsdTracker) Track(event *Event) error {
 	switch event.Properties["Type"] {
-	case goproxy.Duration:
-		return st.PrecisionTiming(stat, event.Properties["Value"].(time.Duration))
-	case goproxy.Count:
-		return st.Incr(stat, event.Properties["Value"].(int64))
-	case goproxy.Gauge:
-		return st.Gauge(stat, event.Properties["Value"].(int64))
-	default:
-		return nil
+	case Timer:
+		st.Timing(event.Event, event.Properties["Value"].(time.Duration))
+	case Counter:
+		st.Count(event.Event, event.Properties["Value"].(int64))
+	case Gauge:
+		st.Gauge(event.Event, event.Properties["Value"].(int64))
+	case Set:
+		st.Unique(event.Event, event.Properties["Value"].(string))
 	}
+
+	return nil
 }

--- a/statsd.go
+++ b/statsd.go
@@ -1,20 +1,47 @@
 package main
 
 import (
+	"log"
 	"time"
 
 	"github.com/alexcesaro/statsd"
 )
 
-type StatsdTracker struct {
+type StatsdClient struct {
 	*statsd.Client
+	options []statsd.Option
+	muted   bool
 }
 
-func NewStatsdTracker(client *statsd.Client) *StatsdTracker {
+func (sc *StatsdClient) Muted() bool {
+	return sc.muted
+}
+
+func NewStatsdClient(opts ...statsd.Option) (*StatsdClient, error) {
+	statsd_client, err := statsd.New(opts...)
+	return &StatsdClient{
+		Client:  statsd_client,
+		options: opts,
+		muted:   err != nil,
+	}, err
+}
+
+type StatsdTracker struct {
+	*StatsdClient
+}
+
+func NewStatsdTracker(client *StatsdClient) *StatsdTracker {
 	return &StatsdTracker{client}
 }
 
 func (st *StatsdTracker) Track(event *Event) error {
+	if st.Muted() {
+		st.StatsdClient, err = NewStatsdClient(st.StatsdClient.options...)
+		if nil != err {
+			log.Println(err)
+		}
+	}
+
 	switch event.Properties["Type"] {
 	case Timer:
 		st.Timing(event.Event, event.Properties["Value"].(time.Duration))

--- a/statsd.go
+++ b/statsd.go
@@ -44,7 +44,7 @@ func (st *StatsdTracker) Track(event *Event) error {
 
 	switch event.Properties["Type"] {
 	case Timer:
-		st.Timing(event.Event, event.Properties["Value"].(time.Duration))
+		st.Timing(event.Event, int(event.Properties["Value"].(time.Duration)/time.Millisecond))
 	case Counter:
 		st.Count(event.Event, event.Properties["Value"].(int64))
 	case Gauge:

--- a/statsd.go
+++ b/statsd.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/quipo/statsd"
+	"github.com/zpencerq/goproxy"
+)
+
+type StatsdTracker struct {
+	*statsd.StatsdClient
+}
+
+func NewStatsdTracker(host string, prefix string) *StatsdTracker {
+	tracker := &StatsdTracker{statsd.NewStatsdClient(host, prefix)}
+	err := tracker.CreateSocket()
+	if nil != err {
+		log.Println(err)
+		os.Exit(1)
+	}
+	return tracker
+}
+
+func (st *StatsdTracker) Track(event *goproxy.Event) error {
+	stat := fmt.Sprintf("%s.%s", event.Event, event.Properties["Host"].(string))
+	switch event.Properties["Type"] {
+	case goproxy.Duration:
+		return st.PrecisionTiming(stat, event.Properties["Value"].(time.Duration))
+	case goproxy.Count:
+		return st.Incr(stat, event.Properties["Value"].(int64))
+	case goproxy.Gauge:
+		return st.Gauge(stat, event.Properties["Value"].(int64))
+	default:
+		return nil
+	}
+}

--- a/statsd.go
+++ b/statsd.go
@@ -25,7 +25,12 @@ func NewStatsdTracker(host string, prefix string) *StatsdTracker {
 }
 
 func (st *StatsdTracker) Track(event *goproxy.Event) error {
-	stat := fmt.Sprintf("%s.%s", event.Event, event.Properties["Host"].(string))
+	host_string := event.Properties["Host"].(string)
+	if protocol, ok := event.Properties["Protocol"]; ok {
+		host_string = fmt.Sprintf("%s.%s", protocol, host_string)
+	}
+	stat := fmt.Sprintf("%s.%s", event.Event, host_string)
+
 	switch event.Properties["Type"] {
 	case goproxy.Duration:
 		return st.PrecisionTiming(stat, event.Properties["Value"].(time.Duration))

--- a/statsd.go
+++ b/statsd.go
@@ -46,9 +46,9 @@ func (st *StatsdTracker) Track(event *Event) error {
 	case Timer:
 		st.Timing(event.Event, int(event.Properties["Value"].(time.Duration)/time.Millisecond))
 	case Counter:
-		st.Count(event.Event, event.Properties["Value"].(int64))
+		st.Count(event.Event, event.Properties["Value"])
 	case Gauge:
-		st.Gauge(event.Event, event.Properties["Value"].(int64))
+		st.Gauge(event.Event, event.Properties["Value"])
 	case Set:
 		st.Unique(event.Event, event.Properties["Value"].(string))
 	}

--- a/tracker.go
+++ b/tracker.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -105,10 +106,24 @@ func NewCompositeTracker(trackers ...Tracker) *CompositeTracker {
 	return composite_tracker
 }
 
+type CompositeError []error
+
+func (ce *CompositeError) Error() string {
+	error_strings := make([]string, len(*ce))
+	for _, err := range *ce {
+		error_strings = append(error_strings, err.Error())
+	}
+	return strings.Join(error_strings[:], "\n")
+}
+
 func (st *CompositeTracker) Track(event *Event) error {
-	var err error
+	errors := make([]error, 0)
+	errs := CompositeError(errors)
 	for _, tracker := range st.trackers {
 		err = tracker.Track(event)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return &errs
 }

--- a/tracker.go
+++ b/tracker.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+)
+
+type EventType int
+
+const (
+	Timer EventType = iota
+	Counter
+	Gauge
+	Set
+)
+
+func (et *EventType) String() string {
+	switch *et {
+	case Timer:
+		return "Timer"
+	case Counter:
+		return "Counter"
+	case Gauge:
+		return "Gauge"
+	case Set:
+		return "Set"
+	default:
+		return "Unknown"
+	}
+}
+
+type Event struct {
+	Event      string                 `json:"event"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+func NewEvent(event string, properties map[string]interface{}) *Event {
+	if properties == nil {
+		properties = make(map[string]interface{})
+	}
+
+	return &Event{Event: event, Properties: properties}
+}
+
+func NewDurationEvent(stat string, start time.Time, properties map[string]interface{}) *Event {
+	if properties == nil {
+		properties = make(map[string]interface{})
+	}
+	event := NewEvent(stat, properties)
+	event.Properties["Value"] = time.Since(start)
+	event.Properties["Type"] = Timer
+	return event
+}
+
+type Tracker interface {
+	Track(event *Event) error
+}
+
+func (wrapper *ProxyHttpServerWrapper) TrackEvent(event *Event) error {
+	return wrapper.Tracker.Track(event)
+}
+
+func (wrapper *ProxyHttpServerWrapper) TrackDuration(event *Event, start time.Time) error {
+	new_event := NewDurationEvent(event.Event, start, event.Properties)
+	return wrapper.Tracker.Track(new_event)
+}
+
+type LogTracker struct {
+	*log.Logger
+}
+
+func NewLogTracker(logger *log.Logger) *LogTracker {
+	if logger == nil {
+		logger = log.New(os.Stderr, "", log.LstdFlags)
+	}
+	return &LogTracker{logger}
+}
+
+func (lt *LogTracker) Track(event *Event) error {
+	lt.Printf("%s - %v", event.Event, event.Properties)
+	return nil
+}
+
+type NoopTracker struct{}
+
+func NewNoopTracker() *NoopTracker {
+	return &NoopTracker{}
+}
+
+func (nt *NoopTracker) Track(event *Event) error {
+	return nil
+}
+
+type CompositeTracker struct {
+	trackers []Tracker
+}
+
+func NewCompositeTracker(trackers ...Tracker) *CompositeTracker {
+	composite_tracker := &CompositeTracker{make([]Tracker, 0)}
+	for _, tracker := range trackers {
+		composite_tracker.trackers = append(composite_tracker.trackers,
+			tracker)
+	}
+	return composite_tracker
+}
+
+func (st *CompositeTracker) Track(event *Event) error {
+	var err error
+	for _, tracker := range st.trackers {
+		err = tracker.Track(event)
+	}
+	return err
+}

--- a/tracker.go
+++ b/tracker.go
@@ -106,6 +106,10 @@ func NewCompositeTracker(trackers ...Tracker) *CompositeTracker {
 	return composite_tracker
 }
 
+func (ct *CompositeTracker) AddTracker(tracker Tracker) {
+	ct.trackers = append(ct.trackers, tracker)
+}
+
 type CompositeError []error
 
 func (ce *CompositeError) Error() string {

--- a/whitelist.go
+++ b/whitelist.go
@@ -21,6 +21,7 @@ type WhitelistManager struct {
 	cache    map[string]bool
 	filename string
 
+	Tracker Tracker
 	Verbose bool
 }
 
@@ -28,6 +29,7 @@ func NewWhitelistManager(filename string) (*WhitelistManager, error) {
 	twm := &WhitelistManager{
 		filename: filename,
 		cache:    make(map[string]bool),
+		Tracker:  NewNoopTracker(),
 	}
 	err = twm.load()
 	return twm, err
@@ -90,6 +92,11 @@ func (wm *WhitelistManager) CheckString(str string) bool {
 			return true
 		}
 	}
+
+	defer wm.Tracker.Track(NewEvent("block", map[string]interface{}{
+		"Value": str,
+		"Type":  Set,
+	}))
 
 	return false
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -35,11 +34,13 @@ func (wrapper *ProxyHttpServerWrapper) ServeHTTP(w http.ResponseWriter, r *http.
 	}
 
 	defer wrapper.TrackDuration(
-		NewEvent(fmt.Sprintf("serve.%s.%s", protocol, host),
+		NewEvent("smykowski.serve",
 			map[string]interface{}{
-				"Host":     host,
-				"Url":      r.URL.Path,
-				"Protocol": protocol,
+				"Tags": map[string]string{
+					"Host":     host,
+					"Protocol": protocol,
+				},
+				"Url": r.URL.Path,
 			}),
 		time.Now())
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/zpencerq/goproxy"
+)
+
+type ProxyHttpServerWrapper struct {
+	*goproxy.ProxyHttpServer
+	Tracker Tracker
+}
+
+func NewProxyWrapper(proxy *goproxy.ProxyHttpServer) *ProxyHttpServerWrapper {
+	return &ProxyHttpServerWrapper{proxy, NewNoopTracker()}
+}
+
+func (wrapper *ProxyHttpServerWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	protocol := "tcp"
+
+	host, port, err := net.SplitHostPort(r.Host)
+	if err == nil { // PROXIED REQUEST
+		if port == "443" {
+			protocol = "https"
+		}
+		if port == "80" {
+			protocol = "http"
+		}
+	} else {
+		protocol = "http"
+		host = r.Host
+	}
+
+	defer wrapper.TrackDuration(
+		NewEvent(fmt.Sprintf("serve.%s.%s", protocol, host),
+			map[string]interface{}{
+				"Host":     host,
+				"Url":      r.URL.Path,
+				"Protocol": protocol,
+			}),
+		time.Now())
+
+	proxy.ServeHTTP(w, r)
+}


### PR DESCRIPTION
Included are several Tracker implementations:
- NoopTracker
- LogTracker
- StatsdTracker
- InfluxDataTracker
- CompositeTracker (to combine other Trackers)

Some changes are nonsensical since I was experimenting with adding the Tracking logic to `goproxy` directly but ended up wrapping it instead in `smykowski`.
